### PR TITLE
perf: HeroCanvas, PhotoReel, mobile scroll reset

### DIFF
--- a/docs/superpowers/specs/2026-05-03-perf-canvas-photoreel-scroll-design.md
+++ b/docs/superpowers/specs/2026-05-03-perf-canvas-photoreel-scroll-design.md
@@ -1,0 +1,66 @@
+# Performance: HeroCanvas, PhotoReel, and Mobile Scroll Reset
+
+**Date:** 2026-05-03
+**Branch:** `perf/canvas-photoreel-scroll`
+
+## Problem
+
+Three issues observed on the live site:
+
+1. **Mobile scroll doesn't reset on navigation.** Tapping a link opens the new page already scrolled partway down.
+2. **WebGL shader is heavier than necessary**, especially on phones.
+3. **PhotoReel images load too late** — scrolling reveals them before they have data.
+
+## Goals
+
+Targeted, low-risk performance pass. Measure with Lighthouse mobile before and after to confirm the gain. No visual regressions.
+
+## Fixes
+
+### 1. Scope HeroCanvas to homepage only
+
+`HeroCanvas` currently mounts in `src/app/layout.tsx` and runs on every route. It's a fullscreen `fixed inset-0` R3F canvas with a continuous-rAF shader, but it's only visually used by the homepage hero and contact section (middle sections cover it with solid backgrounds).
+
+**Change:** Make `HeroCanvas` return `null` unless `usePathname() === '/'`.
+
+Single canvas instance, fixed across the homepage's full scroll height — same as today, just doesn't mount on `/about`, `/projects/*`, `/photography/*`. Two inline canvases (one per visible section) was considered and rejected: doubles WebGL contexts and shader compiles for no user-visible benefit.
+
+### 2. Fix scroll reset on route change
+
+`src/app/template.tsx` wraps every page in a `motion.div` with a `y: 20 → 0` enter animation. Next.js's default scroll restoration races with that transform on mobile and lands the user partway down the new page.
+
+**Change:** Add `useEffect` on `pathname` change in `template.tsx` that calls `window.scrollTo(0, 0)` (instant, not smooth).
+
+### 3. Shader perf
+
+`HeroScene.tsx` does roughly 2× the fragment work it needs to:
+
+- `uResolution.value.set(size.width * 2, size.height * 2)` (line 192) — drop the `*2`. Coordinate math should match the actual canvas pixel dimensions.
+- Canvas uses `dpr={[1, 1.5]}` — keep on desktop, but cap to `[1, 1.25]` on mobile (touch devices). The shader's chroma loop runs 30 `scene()` invocations per pixel; each doubled pixel multiplies that.
+- `STEPS = 10` in the chroma loop — reduce to 6. Visually identical at typical viewing distance.
+- `useFrame` allocates `new Vector2(pointer.x, pointer.y)` every frame — reuse a ref'd Vector2.
+- Pause the rAF loop when the canvas is not visible. Use a `frameloop` toggle driven by an IntersectionObserver watching the hero and contact sections. When neither is in view (i.e., user is reading the projects/text middle of the homepage), set `frameloop="never"`; when one is in view, set back to `"always"`.
+
+### 4. PhotoReel image loading
+
+Root cause: every reel photo has `style={{ display: "none" }}` until the scroll-driven JS reveals it, plus `loading="lazy"`. The browser's lazy-loader can't see hidden elements as "near viewport," so fetching only starts when JS un-hides them — too late at scroll speed.
+
+**Changes:**
+
+- Remove `loading="lazy"` from the reel `<Image>`. Max 20 photos; let the browser fetch them as the homepage loads.
+- Add `fetchPriority="low"` so they queue behind the LCP.
+- Bump `sizes` from `"200px"` to `"400px"`. At scale 4× the displayed width approaches 400px on desktop; the current `200px` causes Next/Image to serve an undersized variant.
+- Add `placeholder="blur"` with `blurDataURL` if available cheaply (skip if it requires a build-step rework).
+
+## Out of scope
+
+- Replacing Framer Motion's page transition with CSS (~40KB gzipped saving) — keep for now, revisit if Lighthouse still shows JS as the bottleneck after these fixes.
+- GSAP/ScrollTrigger import audit — only relevant if there's evidence of unused imports; skip unless the post-fix Lighthouse run flags it.
+- Photography gallery page (`/photography`) image loading — different component, different problem; not what the user described.
+
+## Verification
+
+- `npm run build` succeeds with no new warnings.
+- Visual smoke test: homepage hero animates as before; contact section has shader visible behind it; about/projects/photography pages no longer mount the canvas (DevTools: no `<canvas>` in DOM).
+- Tap a link on mobile (or DevTools mobile emulation) → new page opens at scroll top.
+- Lighthouse mobile run on `/` before/after — record the deltas in the PR description.

--- a/src/app/template.tsx
+++ b/src/app/template.tsx
@@ -1,8 +1,16 @@
 "use client";
 
 import { motion } from "framer-motion";
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
 
 export default function Template({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}

--- a/src/app/template.tsx
+++ b/src/app/template.tsx
@@ -1,14 +1,23 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { useEffect } from "react";
+import { useEffect, useLayoutEffect } from "react";
 import { usePathname } from "next/navigation";
+
+const useIsoLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
 export default function Template({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
 
   useEffect(() => {
-    window.scrollTo(0, 0);
+    if ("scrollRestoration" in window.history) {
+      window.history.scrollRestoration = "manual";
+    }
+  }, []);
+
+  useIsoLayoutEffect(() => {
+    window.scrollTo({ top: 0, left: 0, behavior: "instant" as ScrollBehavior });
   }, [pathname]);
 
   return (

--- a/src/components/canvas/sketches/HeroScene.tsx
+++ b/src/components/canvas/sketches/HeroScene.tsx
@@ -142,7 +142,7 @@ void main() {
   float dispB = pow(distortVec.b, distPow) * CHROMA_AMOUNT;
 
   vec3 color = vec3(0.0);
-  const int STEPS = 10;
+  const int STEPS = 6;
   float inv = 1.0 / float(STEPS);
   for (int i = 1; i <= STEPS; i++) {
     float t = float(i) * inv;
@@ -165,6 +165,7 @@ export default function HeroScene() {
   const meshRef = useRef<Mesh>(null);
   const { size } = useThree();
   const mouseSmooth = useRef(new Vector2(0.5, 0.5));
+  const mouseTarget = useRef(new Vector2(0.5, 0.5));
 
   const material = useMemo(() => {
     return new ShaderMaterial({
@@ -184,12 +185,10 @@ export default function HeroScene() {
   useFrame(({ pointer, clock }) => {
     if (!material) return;
     material.uniforms.uTime.value = clock.elapsedTime;
-    mouseSmooth.current.lerp(
-      new Vector2((pointer.x + 1) * 0.5, (pointer.y + 1) * 0.5),
-      0.03
-    );
+    mouseTarget.current.set((pointer.x + 1) * 0.5, (pointer.y + 1) * 0.5);
+    mouseSmooth.current.lerp(mouseTarget.current, 0.03);
     material.uniforms.uMouse.value.copy(mouseSmooth.current);
-    material.uniforms.uResolution.value.set(size.width * 2, size.height * 2);
+    material.uniforms.uResolution.value.set(size.width, size.height);
 
     const t = Math.min(1, clock.elapsedTime / 4);
     material.uniforms.uRadius.value = (t === 1 ? 1 : 1 - Math.pow(2, -10 * t)) * 0.85;

--- a/src/components/ui/ContactSection.tsx
+++ b/src/components/ui/ContactSection.tsx
@@ -94,7 +94,7 @@ export default function ContactSection() {
   }, []);
 
   return (
-    <section className="relative min-h-screen flex flex-col justify-center overflow-hidden">
+    <section data-canvas-show className="relative min-h-screen flex flex-col justify-center overflow-hidden">
       {/* Marquee */}
       <div className="mb-20 md:mb-28 overflow-hidden py-4">
         <div

--- a/src/components/ui/HeroCanvas.tsx
+++ b/src/components/ui/HeroCanvas.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from "next/dynamic";
 import { Canvas as R3FCanvas } from "@react-three/fiber";
-import { Suspense } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 
 const HeroScene = dynamic(
@@ -16,6 +16,43 @@ export default function HeroCanvas() {
   const pathname = usePathname();
   const hidden = HIDDEN_ON.some((prefix) => pathname.startsWith(prefix));
 
+  const [isTouch, setIsTouch] = useState(false);
+  const [active, setActive] = useState(true);
+
+  useEffect(() => {
+    setIsTouch(
+      "ontouchstart" in window || navigator.maxTouchPoints > 0
+    );
+  }, []);
+
+  // Pause rAF when no [data-canvas-show] section is on screen.
+  // Pages without those markers (e.g. /about) keep the canvas always-on.
+  useEffect(() => {
+    if (hidden) return;
+    const targets = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-canvas-show]")
+    );
+    if (targets.length === 0) {
+      setActive(true);
+      return;
+    }
+
+    const visible = new Set<Element>();
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) visible.add(entry.target);
+          else visible.delete(entry.target);
+        }
+        setActive(visible.size > 0);
+      },
+      { threshold: 0 }
+    );
+
+    targets.forEach((t) => io.observe(t));
+    return () => io.disconnect();
+  }, [pathname, hidden]);
+
   if (hidden) return null;
 
   return (
@@ -23,8 +60,9 @@ export default function HeroCanvas() {
       <R3FCanvas
         orthographic
         camera={{ zoom: 1, position: [0, 0, 1], near: 0.1, far: 10 }}
-        dpr={[1, 1.5]}
-        gl={{ antialias: false, alpha: true }}
+        dpr={isTouch ? [1, 1.25] : [1, 1.5]}
+        gl={{ antialias: false, alpha: true, powerPreference: "high-performance" }}
+        frameloop={active ? "always" : "never"}
         style={{ width: "100%", height: "100%" }}
       >
         <Suspense fallback={null}>

--- a/src/components/ui/HeroSection.tsx
+++ b/src/components/ui/HeroSection.tsx
@@ -65,6 +65,7 @@ export default function HeroSection() {
   return (
     <section
       ref={sectionRef}
+      data-canvas-show
       className="relative min-h-[100dvh] flex items-center md:items-end px-5 md:px-8 pb-0 md:pb-16"
     >
       <div ref={contentRef} className="relative z-10 pb-20 w-full max-w-5xl">

--- a/src/components/ui/PhotoReel.tsx
+++ b/src/components/ui/PhotoReel.tsx
@@ -178,8 +178,8 @@ export default function PhotoReel({ photos, maxPhotos = 20 }: PhotoReelProps) {
                   alt={photo.alt}
                   fill
                   className="object-cover"
-                  sizes="200px"
-                  loading="lazy"
+                  sizes="400px"
+                  fetchPriority="low"
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Scope `HeroCanvas` to `/` and `/about`; hidden on project/photography pages (already on master) + pause rAF when neither hero nor contact section is in viewport
- Shader: `STEPS` 10→6, drop redundant `*2` on `uResolution`, cap `dpr` to `[1, 1.25]` on touch, reuse `Vector2` instead of allocating per frame
- `PhotoReel`: drop `loading=lazy` (was blocked by `display:none` and never preloading), bump `sizes` to `400px`, add `fetchPriority=low`
- `template.tsx`: `useLayoutEffect` + `history.scrollRestoration = "manual"` + `behavior: "instant"` so route changes land at top on mobile

Spec: [docs/superpowers/specs/2026-05-03-perf-canvas-photoreel-scroll-design.md](https://github.com/muniatu/portfolio/blob/perf/canvas-photoreel-scroll/docs/superpowers/specs/2026-05-03-perf-canvas-photoreel-scroll-design.md)

## Test plan
- [x] Homepage renders identically (hero + contact both show shader)
- [ ] `/about` still shows the canvas
- [ ] Project / photography pages have no `<canvas>` in DOM
- [ ] Scroll into the projects/text middle of `/`, confirm GPU usage drops (DevTools Performance)
- [ ] On mobile: scroll partway down `/`, tap a project link → opens at top
- [ ] PhotoReel photos load before they enter the s-curve (throttle Slow 4G to test)
- [ ] Lighthouse mobile run on `/` — record before/after