### PR TITLE
feat: mood bubbles, coffee page route, host grotesk font

### DIFF
--- a/src/components/mdx/index.tsx
+++ b/src/components/mdx/index.tsx
@@ -11,6 +11,7 @@ import NespressoOatlyVideo from "../projects/nespresso/NespressoOatlyVideo";
 import NespressoRecycling from "../projects/nespresso/NespressoRecycling";
 import NespressoBoutique from "../projects/nespresso/NespressoBoutique";
 import NespressoFooter from "../projects/nespresso/NespressoFooter";
+import NespressoMoodBubbles from "../projects/nespresso/NespressoMoodBubbles";
 
 export const mdxComponents: MDXComponents = {
   ProjectImage,
@@ -25,4 +26,5 @@ export const mdxComponents: MDXComponents = {
   NespressoRecycling,
   NespressoBoutique,
   NespressoFooter,
+  NespressoMoodBubbles,
 };

--- a/src/components/projects/nespresso/NespressoBoutique.tsx
+++ b/src/components/projects/nespresso/NespressoBoutique.tsx
@@ -33,7 +33,7 @@ export default function NespressoBoutique({
         />
 
         <div className="absolute bottom-4 left-3 text-white">
-          <div className="text-[12px] font-normal uppercase tracking-wider opacity-90">
+          <div className="text-[12px] font-normal opacity-90">
             {eyebrow}
           </div>
           <div className="text-[22px] font-normal leading-tight">{title}</div>

--- a/src/components/projects/nespresso/NespressoCoffeeCorner.tsx
+++ b/src/components/projects/nespresso/NespressoCoffeeCorner.tsx
@@ -180,7 +180,7 @@ export default function NespressoCoffeeCorner({
             }}
           />
           <div className="absolute inset-x-0 bottom-4 px-3 text-white">
-            <div className="text-[12px] font-normal uppercase tracking-wider opacity-90">
+            <div className="text-[12px] font-normal opacity-90">
               {mainEyebrow}
             </div>
             <div className="text-[22px] font-normal leading-snug">
@@ -224,7 +224,7 @@ export default function NespressoCoffeeCorner({
         />
         <div className="absolute inset-x-0 bottom-4 flex items-end justify-between px-3 text-white">
           <div>
-            <div className="text-[12px] font-normal uppercase tracking-wider opacity-90">
+            <div className="text-[12px] font-normal opacity-90">
               {recipeEyebrow}
             </div>
             <div className="text-[22px] font-normal leading-snug">

--- a/src/components/projects/nespresso/NespressoCoffeePage.tsx
+++ b/src/components/projects/nespresso/NespressoCoffeePage.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "./_router-context";
+import NespressoStatusBar from "./NespressoStatusBar";
+import NespressoNavBar from "./NespressoNavBar";
+import NespressoFooter from "./NespressoFooter";
+
+type Product = {
+  id: string;
+  name: string;
+  intensity: number;
+  price: number; // EUR per sleeve
+  capsules: number;
+  bg: string; // card background tint
+};
+
+// Hardcoded sample list — colours nod to Nespresso's pastel grid.
+const PRODUCTS: Product[] = [
+  { id: "diavolitto", name: "Diavolitto", intensity: 11, price: 7.7, capsules: 10, bg: "#F4ECE3" },
+  { id: "alapie",     name: "Alapie Power", intensity: 9,  price: 5.9, capsules: 10, bg: "#FCE7DD" },
+  { id: "whisky",     name: "Whisky Essence", intensity: 8, price: 5.9, capsules: 10, bg: "#F1E4D5" },
+  { id: "forest",     name: "Forest Fruit", intensity: 6, price: 5.9, capsules: 10, bg: "#F2E9DD" },
+  { id: "ginseng",    name: "Ginseng Delight", intensity: 7, price: 5.9, capsules: 10, bg: "#EFE4D2" },
+  { id: "strawberry", name: "Strawberry White Chocolate", intensity: 5, price: 5.9, capsules: 10, bg: "#FAE2DA" },
+  { id: "decaso",     name: "Decaso", intensity: 6, price: 5.9, capsules: 10, bg: "#F3EBDC" },
+  { id: "calorima",   name: "Calorima", intensity: 8, price: 5.9, capsules: 10, bg: "#FBEED2" },
+  { id: "almasta",    name: "Almasta", intensity: 7, price: 5.9, capsules: 10, bg: "#F8E7D9" },
+  { id: "alcalia",    name: "Alcalia decaffeinato", intensity: 5, price: 5.9, capsules: 10, bg: "#F4E6CF" },
+  { id: "diavolore",  name: "Diavolore", intensity: 12, price: 5.9, capsules: 10, bg: "#EFE3D0" },
+  { id: "cuba",       name: "Café de Cuba", intensity: 9, price: 5.9, capsules: 10, bg: "#FBEFE0" },
+  { id: "rastine",    name: "Rastine reforzegada", intensity: 10, price: 5.9, capsules: 10, bg: "#F0E5D5" },
+  { id: "blue",       name: "Blue Bestio", intensity: 7, price: 5.9, capsules: 10, bg: "#E5EEF1" },
+  { id: "rica",       name: "Costa Rica", intensity: 8, price: 5.9, capsules: 10, bg: "#F2E8D7" },
+  { id: "kona",       name: "Hawaii Kona", intensity: 6, price: 5.9, capsules: 10, bg: "#F7EBD3" },
+  { id: "diluso",     name: "Diluso", intensity: 7, price: 5.9, capsules: 10, bg: "#EFE7D5" },
+  { id: "pep",        name: "Peppermint", intensity: 5, price: 5.9, capsules: 10, bg: "#E8F0E0" },
+];
+
+const FILTERS = ["Vertuo", "Collection", "Cup size", "Intensity"];
+
+function CapsuleIcon() {
+  return (
+    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" aria-hidden>
+      <path
+        d="M7 4h10l-1.5 16h-7Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function PlusIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden>
+      <path d="M12 5v14M5 12h14" />
+    </svg>
+  );
+}
+
+function MinusIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden>
+      <path d="M5 12h14" />
+    </svg>
+  );
+}
+
+function ProductCard({ product }: { product: Product }) {
+  const [count, setCount] = useState(0);
+  const inCart = count > 0;
+
+  return (
+    <div
+      className="relative flex h-[194px] flex-col justify-between overflow-hidden rounded-2xl p-3"
+      style={{ backgroundColor: product.bg }}
+    >
+      <div className="text-[14px] font-normal leading-tight text-black">
+        {product.name}
+      </div>
+
+      {inCart ? (
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            aria-label="Decrease"
+            onClick={() => setCount((c) => Math.max(0, c - 1))}
+            className="flex h-9 w-9 items-center justify-center rounded-full bg-black/10 text-black"
+          >
+            <MinusIcon />
+          </button>
+          <div className="text-[12px] text-black">
+            {count} sleeve{count > 1 ? "s" : ""}
+          </div>
+          <button
+            type="button"
+            aria-label="Increase"
+            onClick={() => setCount((c) => c + 1)}
+            className="flex h-9 w-9 items-center justify-center rounded-full bg-black/10 text-black"
+          >
+            <PlusIcon />
+          </button>
+        </div>
+      ) : (
+        <div className="flex items-end justify-between">
+          <div className="text-[11px] leading-snug text-black/70">
+            <div>Intensity: {product.intensity}/13</div>
+            <div className="mt-0.5 flex items-center gap-1">
+              €{product.price.toFixed(2)}
+              <span className="opacity-60">({product.capsules}</span>
+              <CapsuleIcon />
+              <span className="opacity-60">)</span>
+            </div>
+          </div>
+          <button
+            type="button"
+            aria-label={`Add ${product.name}`}
+            onClick={() => setCount(1)}
+            className="flex h-9 w-9 items-center justify-center rounded-full bg-black/10 text-black"
+          >
+            <PlusIcon />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FilterChip({ label }: { label: string }) {
+  return (
+    <button
+      type="button"
+      className="inline-flex h-8 shrink-0 items-center gap-1 rounded-full border border-stone-300 bg-white px-3 text-[13px] font-normal text-black"
+    >
+      <span>{label}</span>
+      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+        <path d="m6 9 6 6 6-6" />
+      </svg>
+    </button>
+  );
+}
+
+export default function NespressoCoffeePage() {
+  const { navigate } = useRouter();
+
+  return (
+    <div className="bg-white">
+      <NespressoStatusBar />
+      <NespressoNavBar />
+
+      {/* Header: title + back link + concierge */}
+      <div className="px-4 pt-3">
+        <button
+          type="button"
+          onClick={() => navigate("home")}
+          className="mb-3 inline-flex items-center gap-1 text-[13px] font-normal text-stone-500"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+            <path d="m15 18-6-6 6-6" />
+          </svg>
+          Back
+        </button>
+        <h1 className="text-[34px] font-normal leading-tight text-black">
+          Coffee
+        </h1>
+
+        {/* Concierge / search */}
+        <button
+          type="button"
+          className="mt-4 flex h-12 w-full items-center gap-3 rounded-full border border-stone-200 bg-white px-5 text-left text-[14px] text-stone-500"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.3-4.3" />
+          </svg>
+          What are you looking for?
+        </button>
+
+        {/* Filter chips */}
+        <div className="-mx-4 mt-4 flex gap-2 overflow-x-auto px-4 pb-1" style={{ scrollbarWidth: "none" }}>
+          {FILTERS.map((f) => (
+            <FilterChip key={f} label={f} />
+          ))}
+        </div>
+      </div>
+
+      {/* Product grid */}
+      <div className="px-4 pb-6 pt-5">
+        <div className="grid grid-cols-2 gap-3">
+          {PRODUCTS.map((p) => (
+            <ProductCard key={p.id} product={p} />
+          ))}
+        </div>
+      </div>
+
+      <NespressoFooter />
+    </div>
+  );
+}

--- a/src/components/projects/nespresso/NespressoFrame.tsx
+++ b/src/components/projects/nespresso/NespressoFrame.tsx
@@ -2,7 +2,9 @@
 
 import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import { MenuProvider } from "./_menu-context";
+import { RouterProvider, useRouter } from "./_router-context";
 import NespressoMenu from "./NespressoMenu";
+import NespressoCoffeePage from "./NespressoCoffeePage";
 
 type Props = {
   children: ReactNode;
@@ -10,33 +12,37 @@ type Props = {
   width?: number;
 };
 
-const DRAG_THRESHOLD = 4; // px before a click is reclassified as a drag
+const DRAG_THRESHOLD = 4;
 
 // Mockup PNG dimensions (Phone.png is 448 × 916).
 const FRAME_W = 448;
 const FRAME_H = 916;
-// Bezel insets as percentages of the frame.
 const BEZEL_LEFT_PCT = 5.36;
 const BEZEL_RIGHT_PCT = 4.91;
-// Symmetric insets that match the PNG's screen edges.
 const BEZEL_TOP_PCT = 2.2;
 const BEZEL_BOTTOM_PCT = 2.2;
-// Border radius on the inner scroll viewport — matches the PNG screen corners.
 const SCREEN_RADIUS = 60;
-// Momentum / inertia tuning
-const VELOCITY_DECAY = 0.94; // per ~16ms frame
-const MIN_VELOCITY = 0.02; // px/ms — stop threshold
+const VELOCITY_DECAY = 0.94;
+const MIN_VELOCITY = 0.02;
 const VELOCITY_SAMPLE_WINDOW_MS = 80;
 
 /**
  * Phone-shaped chrome that wraps the interactive Nespresso prototype.
- * Uses a real mockup PNG (with notch and side buttons baked in) as the
- * visual frame and positions the scrollable content over the screen area.
- *
- * On desktop the contents are drag-scrollable with a translucent circle
- * cursor; on touch devices, native scrolling is used.
+ * Sets up router + menu contexts and delegates all rendering & input
+ * handling to the inner component, which can read those contexts.
  */
-export default function NespressoFrame({ children, width = FRAME_W }: Props) {
+export default function NespressoFrame(props: Props) {
+  return (
+    <RouterProvider>
+      <MenuProvider>
+        <FrameInner {...props} />
+      </MenuProvider>
+    </RouterProvider>
+  );
+}
+
+function FrameInner({ children, width = FRAME_W }: Props) {
+  const { page } = useRouter();
   const scrollRef = useRef<HTMLDivElement>(null);
   const cursorRef = useRef<HTMLDivElement>(null);
   const screenRef = useRef<HTMLDivElement>(null);
@@ -46,7 +52,6 @@ export default function NespressoFrame({ children, width = FRAME_W }: Props) {
     startY: 0,
     startScrollTop: 0,
     moved: false,
-    /** Recent {y, t} samples used to compute fling velocity */
     samples: [] as { y: number; t: number }[],
   });
   const momentumRaf = useRef<number | null>(null);
@@ -62,7 +67,6 @@ export default function NespressoFrame({ children, width = FRAME_W }: Props) {
   }, []);
 
   const startMomentum = useCallback((initialVelocity: number) => {
-    // initialVelocity in px/ms applied to scrollTop
     let v = initialVelocity;
     let last = performance.now();
     const tick = () => {
@@ -71,7 +75,6 @@ export default function NespressoFrame({ children, width = FRAME_W }: Props) {
       const dt = now - last;
       last = now;
       scrollRef.current.scrollTop += v * dt;
-      // exponential decay normalized to ~16ms frames
       v *= Math.pow(VELOCITY_DECAY, dt / 16.67);
       if (Math.abs(v) > MIN_VELOCITY) {
         momentumRaf.current = requestAnimationFrame(tick);
@@ -99,10 +102,8 @@ export default function NespressoFrame({ children, width = FRAME_W }: Props) {
       }
       scrollRef.current.scrollTop = dragState.current.startScrollTop - deltaY;
 
-      // Track velocity samples
       const now = performance.now();
       dragState.current.samples.push({ y: e.clientY, t: now });
-      // Drop samples older than the window
       while (
         dragState.current.samples.length > 0 &&
         now - dragState.current.samples[0].t > VELOCITY_SAMPLE_WINDOW_MS
@@ -115,7 +116,6 @@ export default function NespressoFrame({ children, width = FRAME_W }: Props) {
   const onPointerDown = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       if (e.pointerType !== "mouse" || !scrollRef.current) return;
-      // Tapping the frame interrupts any active fling
       cancelMomentum();
       dragState.current = {
         pointerId: e.pointerId,
@@ -125,9 +125,6 @@ export default function NespressoFrame({ children, width = FRAME_W }: Props) {
         samples: [{ y: e.clientY, t: performance.now() }],
       };
       setPressing(true);
-      // NOTE: deliberately not calling setPointerCapture — capture redirects
-      // pointer events but interacts badly with the synthesised click event,
-      // making inner buttons unreachable in some browsers.
     },
     [cancelMomentum]
   );
@@ -140,23 +137,12 @@ export default function NespressoFrame({ children, width = FRAME_W }: Props) {
       const samples = dragState.current.samples;
       dragState.current.pointerId = null;
 
-      if (wasDragged) {
-        // Click suppression is handled in onClickCapture (capture phase),
-        // not via preventDefault here — preventDefault on pointerup can
-        // cancel the compat click on inner buttons we DO want to fire.
-
-        // Compute fling velocity from the recent sample window
-        if (samples.length >= 2) {
-          const first = samples[0];
-          const last = samples[samples.length - 1];
-          const dt = last.t - first.t;
-          const dy = last.y - first.y;
-          if (dt > 0) {
-            // dragging up = dy<0 = scrollTop should keep increasing
-            // scrollTop delta we applied per ms ≈ -dy/dt, so seed momentum with that
-            startMomentum(-dy / dt);
-          }
-        }
+      if (wasDragged && samples.length >= 2) {
+        const first = samples[0];
+        const last = samples[samples.length - 1];
+        const dt = last.t - first.t;
+        const dy = last.y - first.y;
+        if (dt > 0) startMomentum(-dy / dt);
       }
     },
     [startMomentum]
@@ -184,16 +170,21 @@ export default function NespressoFrame({ children, width = FRAME_W }: Props) {
   // Cleanup any in-flight RAF on unmount
   useEffect(() => () => cancelMomentum(), [cancelMomentum]);
 
+  // Reset scroll position when the route changes so each page lands at top
+  useEffect(() => {
+    if (scrollRef.current) scrollRef.current.scrollTop = 0;
+    cancelMomentum();
+  }, [page, cancelMomentum]);
+
   return (
-    <MenuProvider>
-    <div className="not-prose my-12 flex justify-center">
+    <div
+      className="not-prose my-12 flex justify-center"
+      style={{ fontFamily: '"Host Grotesk", system-ui, sans-serif' }}
+    >
       <div
         className="relative inline-block"
         style={{ width: `min(100%, ${width}px)` }}
       >
-        {/* Mockup PNG drives the wrapper's height naturally:
-            displayed at its intrinsic aspect ratio, max-width 100%.
-            Using a plain <img> so the layout is always exactly W × W·(916/448). */}
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           src="/images/projects/nespresso/mockup/Phone.png"
@@ -205,7 +196,6 @@ export default function NespressoFrame({ children, width = FRAME_W }: Props) {
           className="pointer-events-none relative z-20 block h-auto w-full select-none"
         />
 
-        {/* Screen — interactive scrollable area, sits beneath the mockup */}
         <div
           ref={screenRef}
           className="absolute z-10 overflow-hidden bg-white"
@@ -233,17 +223,17 @@ export default function NespressoFrame({ children, width = FRAME_W }: Props) {
               scrollbarWidth: "none",
             }}
           >
-            {children}
+            {page === "home" ? children : <NespressoCoffeePage />}
           </div>
 
-          {/* Menu overlay — fades in over the screen when burger is tapped */}
+          {/* Menu overlay — sits above the scrollable area on every route */}
           <NespressoMenu />
 
           {/* Translucent circle cursor (desktop only) */}
           <div
             ref={cursorRef}
             aria-hidden
-            className="pointer-events-none absolute left-0 top-0 z-30 hidden rounded-full backdrop-blur-sm transition-[width,height,background] duration-150 md:block"
+            className="pointer-events-none absolute left-0 top-0 z-40 hidden rounded-full backdrop-blur-sm transition-[width,height,background] duration-150 md:block"
             style={{
               width: pressing ? 36 : 28,
               height: pressing ? 36 : 28,
@@ -258,6 +248,5 @@ export default function NespressoFrame({ children, width = FRAME_W }: Props) {
         </div>
       </div>
     </div>
-    </MenuProvider>
   );
 }

--- a/src/components/projects/nespresso/NespressoHero.tsx
+++ b/src/components/projects/nespresso/NespressoHero.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { useRouter } from "./_router-context";
+
 type Props = {
   /** Path to the looping hero video. Provide both mp4 and webm if available. */
   videoMp4?: string;
@@ -22,6 +26,7 @@ export default function NespressoHero({
   title = "Welcome\nCoffee Lover",
   ctaLabel = "Shop Coffee",
 }: Props) {
+  const { navigate } = useRouter();
   return (
     <section className="relative px-4 pt-[10px]">
       <div className="relative h-[582px] w-full overflow-hidden rounded-3xl bg-stone-200">
@@ -56,6 +61,7 @@ export default function NespressoHero({
 
           <button
             type="button"
+            onClick={() => navigate("coffee")}
             className="inline-flex h-[50px] items-center gap-2 rounded-full bg-white px-6 text-[15px] font-normal text-black shadow-lg"
           >
             <span>{ctaLabel}</span>

--- a/src/components/projects/nespresso/NespressoMoodBubbles.tsx
+++ b/src/components/projects/nespresso/NespressoMoodBubbles.tsx
@@ -1,0 +1,326 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+const SIZE = 80;
+const RADIUS = SIZE / 2;
+const BORDER = 1.5;
+// Collide on the visible border so bubble outlines never overlap.
+const VISIBLE_RADIUS = RADIUS + BORDER / 2;
+const COLLISION_DIAMETER = VISIBLE_RADIUS * 2;
+
+// Four-colour palette. Each entry has a solid colour used both as the
+// border (unselected) and as the fill (selected, white text on top).
+const COLORS = {
+  purple: "#5C3D8C",
+  brown: "#8B5E3C",
+  amber: "#C8941A",
+  blue: "#4060B0",
+} as const;
+
+type ColorKey = keyof typeof COLORS;
+
+type BubbleData = { id: string; label: string; color: ColorKey };
+
+const BUBBLES: BubbleData[] = [
+  { id: "rich", label: "Rich", color: "brown" },
+  { id: "classic", label: "Classic", color: "amber" },
+  { id: "fun", label: "Fun", color: "blue" },
+  { id: "energetic", label: "Energetic", color: "purple" },
+  { id: "cozy", label: "Cozy", color: "blue" },
+  { id: "on-ice", label: "On ice", color: "brown" },
+  { id: "calm", label: "Calm", color: "purple" },
+  { id: "cool", label: "Cool", color: "amber" },
+  { id: "shaked", label: "Shaked", color: "brown" },
+  { id: "sweet", label: "Sweet", color: "blue" },
+  { id: "bold", label: "Bold", color: "amber" },
+];
+
+type Body = {
+  id: string;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  isDragging: boolean;
+};
+
+// Physics tuning
+const AMBIENT_IMPULSE_PROB = 0.012; // chance per frame of a tiny push
+const AMBIENT_IMPULSE_MAG = 0.18; // magnitude of that push (px/frame)
+const DAMPING = 0.985;
+const COLLISION_RESTITUTION = 0.7;
+const WALL_RESTITUTION = 0.55;
+const MAX_VELOCITY = 12;
+
+export default function NespressoMoodBubbles({
+  title = "How are you feeling today?",
+  ctaLabel = "Let's make some coffee",
+}: {
+  title?: string;
+  ctaLabel?: string;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const elsRef = useRef<Record<string, HTMLDivElement | null>>({});
+  const bodiesRef = useRef<Body[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  // Initialise bubble positions once we know the container's size.
+  useEffect(() => {
+    const c = containerRef.current;
+    if (!c) return;
+    const rect = c.getBoundingClientRect();
+
+    // Distribute initial positions on a loose grid + jitter so collisions
+    // ripple them apart organically without overlap on first frame.
+    const cols = 3;
+    const rows = Math.ceil(BUBBLES.length / cols);
+    const cellW = rect.width / cols;
+    const cellH = rect.height / rows;
+
+    bodiesRef.current = BUBBLES.map((b, i) => {
+      const col = i % cols;
+      const row = Math.floor(i / cols);
+      return {
+        id: b.id,
+        x: cellW * (col + 0.5) + (Math.random() - 0.5) * 12,
+        y: cellH * (row + 0.5) + (Math.random() - 0.5) * 12,
+        vx: (Math.random() - 0.5) * 0.8,
+        vy: (Math.random() - 0.5) * 0.8,
+        isDragging: false,
+      };
+    });
+  }, []);
+
+  // Physics + render loop.
+  useEffect(() => {
+    let raf = 0;
+
+    const tick = () => {
+      const c = containerRef.current;
+      if (!c) {
+        raf = requestAnimationFrame(tick);
+        return;
+      }
+      const W = c.clientWidth;
+      const H = c.clientHeight;
+      const bodies = bodiesRef.current;
+
+      // 1. Integrate motion + ambient drift + boundary clamp
+      for (const body of bodies) {
+        if (body.isDragging) continue;
+
+        if (Math.random() < AMBIENT_IMPULSE_PROB) {
+          body.vx += (Math.random() - 0.5) * AMBIENT_IMPULSE_MAG * 2;
+          body.vy += (Math.random() - 0.5) * AMBIENT_IMPULSE_MAG * 2;
+        }
+
+        // Cap speed
+        const speed = Math.hypot(body.vx, body.vy);
+        if (speed > MAX_VELOCITY) {
+          body.vx = (body.vx / speed) * MAX_VELOCITY;
+          body.vy = (body.vy / speed) * MAX_VELOCITY;
+        }
+
+        body.x += body.vx;
+        body.y += body.vy;
+        body.vx *= DAMPING;
+        body.vy *= DAMPING;
+
+        if (body.x - VISIBLE_RADIUS < 0) {
+          body.x = VISIBLE_RADIUS;
+          body.vx = Math.abs(body.vx) * WALL_RESTITUTION;
+        } else if (body.x + VISIBLE_RADIUS > W) {
+          body.x = W - VISIBLE_RADIUS;
+          body.vx = -Math.abs(body.vx) * WALL_RESTITUTION;
+        }
+        if (body.y - VISIBLE_RADIUS < 0) {
+          body.y = VISIBLE_RADIUS;
+          body.vy = Math.abs(body.vy) * WALL_RESTITUTION;
+        } else if (body.y + VISIBLE_RADIUS > H) {
+          body.y = H - VISIBLE_RADIUS;
+          body.vy = -Math.abs(body.vy) * WALL_RESTITUTION;
+        }
+      }
+
+      // 2. Pairwise circle collisions
+      for (let i = 0; i < bodies.length; i++) {
+        for (let j = i + 1; j < bodies.length; j++) {
+          const a = bodies[i];
+          const b = bodies[j];
+          const dx = b.x - a.x;
+          const dy = b.y - a.y;
+          let dist = Math.hypot(dx, dy);
+          const minDist = COLLISION_DIAMETER;
+
+          if (dist < minDist) {
+            // Avoid div-by-zero if perfectly stacked
+            if (dist === 0) {
+              dist = 0.01;
+            }
+            const nx = dx / dist;
+            const ny = dy / dist;
+            const overlap = minDist - dist;
+
+            // Position separation. If one is being dragged, it doesn't move
+            // — the other absorbs all the displacement.
+            if (a.isDragging && !b.isDragging) {
+              b.x += nx * overlap;
+              b.y += ny * overlap;
+            } else if (b.isDragging && !a.isDragging) {
+              a.x -= nx * overlap;
+              a.y -= ny * overlap;
+            } else if (!a.isDragging && !b.isDragging) {
+              const half = overlap / 2;
+              a.x -= nx * half;
+              a.y -= ny * half;
+              b.x += nx * half;
+              b.y += ny * half;
+            }
+
+            // Velocity exchange along the normal (equal-mass elastic-ish)
+            const relV = (a.vx - b.vx) * nx + (a.vy - b.vy) * ny;
+            if (relV > 0) {
+              const impulse = relV * COLLISION_RESTITUTION;
+              if (!a.isDragging) {
+                a.vx -= nx * impulse;
+                a.vy -= ny * impulse;
+              }
+              if (!b.isDragging) {
+                b.vx += nx * impulse;
+                b.vy += ny * impulse;
+              }
+            }
+          }
+        }
+      }
+
+      // 3. Write to DOM
+      for (const body of bodies) {
+        const el = elsRef.current[body.id];
+        if (el) {
+          el.style.transform = `translate3d(${body.x - RADIUS}px, ${body.y - RADIUS}px, 0)`;
+        }
+      }
+
+      raf = requestAnimationFrame(tick);
+    };
+
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  // Drag handler — overrides body position to pointer, computes release velocity.
+  const startDrag = (id: string, e: React.PointerEvent<HTMLDivElement>) => {
+    const c = containerRef.current;
+    const body = bodiesRef.current.find((b) => b.id === id);
+    if (!c || !body) return;
+
+    // Don't let the parent frame's drag-to-scroll see this pointer.
+    e.stopPropagation();
+
+    body.isDragging = true;
+    body.vx = 0;
+    body.vy = 0;
+
+    const rect = c.getBoundingClientRect();
+    let lastX = e.clientX;
+    let lastY = e.clientY;
+    let lastT = performance.now();
+    let totalMoved = 0;
+
+    const onMove = (ev: PointerEvent) => {
+      totalMoved += Math.abs(ev.clientX - lastX) + Math.abs(ev.clientY - lastY);
+      const now = performance.now();
+      const dt = Math.max(now - lastT, 1);
+
+      body.x = ev.clientX - rect.left;
+      body.y = ev.clientY - rect.top;
+      // Approximate velocity in px/frame at 60fps
+      body.vx = ((ev.clientX - lastX) / dt) * 16;
+      body.vy = ((ev.clientY - lastY) / dt) * 16;
+
+      lastX = ev.clientX;
+      lastY = ev.clientY;
+      lastT = now;
+    };
+
+    const onUp = () => {
+      body.isDragging = false;
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onUp);
+
+      // Tap (no real movement) → toggle selection
+      if (totalMoved < 6) {
+        setSelected((prev) => {
+          const next = new Set(prev);
+          if (next.has(id)) next.delete(id);
+          else next.add(id);
+          return next;
+        });
+      }
+    };
+
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onUp);
+  };
+
+  const hasSelection = selected.size > 0;
+
+  return (
+    <section className="px-4 py-3">
+      <div className="rounded-3xl bg-stone-100 p-5">
+        <h2 className="text-[26px] font-normal leading-tight text-black">
+          {title}
+        </h2>
+
+        <div
+          ref={containerRef}
+          className="relative my-5 h-[340px] w-full"
+          aria-label="Mood selection"
+        >
+          {BUBBLES.map((b) => {
+            const isSelected = selected.has(b.id);
+            const color = COLORS[b.color];
+            return (
+              <div
+                key={b.id}
+                ref={(el) => {
+                  elsRef.current[b.id] = el;
+                }}
+                onPointerDown={(e) => startDrag(b.id, e)}
+                role="checkbox"
+                aria-checked={isSelected}
+                aria-label={b.label}
+                className="absolute left-0 top-0 flex select-none items-center justify-center rounded-full text-[14px] font-normal transition-[background,color] duration-200"
+                style={{
+                  width: SIZE,
+                  height: SIZE,
+                  borderWidth: 1.5,
+                  borderStyle: "solid",
+                  borderColor: color,
+                  background: isSelected ? color : "transparent",
+                  color: isSelected ? "#ffffff" : color,
+                  touchAction: "none",
+                  willChange: "transform",
+                }}
+              >
+                {b.label}
+              </div>
+            );
+          })}
+        </div>
+
+        <button
+          type="button"
+          disabled={!hasSelection}
+          className="flex h-[52px] items-center justify-center rounded-full bg-black px-6 text-[15px] font-normal text-white transition-opacity duration-200 disabled:opacity-25"
+        >
+          {ctaLabel}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/projects/nespresso/NespressoRecycling.tsx
+++ b/src/components/projects/nespresso/NespressoRecycling.tsx
@@ -34,7 +34,7 @@ export default function NespressoRecycling({
 
         <div className="absolute inset-x-0 bottom-4 flex items-end justify-between px-3 text-white">
           <div>
-            <div className="text-[12px] font-normal uppercase tracking-wider opacity-90">
+            <div className="text-[12px] font-normal opacity-90">
               {eyebrow}
             </div>
             <div className="text-[22px] font-normal leading-tight">{title}</div>

--- a/src/components/projects/nespresso/_router-context.tsx
+++ b/src/components/projects/nespresso/_router-context.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+type Page = "home" | "coffee";
+
+type RouterCtx = {
+  page: Page;
+  navigate: (page: Page) => void;
+};
+
+const Ctx = createContext<RouterCtx>({
+  page: "home",
+  navigate: () => {},
+});
+
+export function useRouter() {
+  return useContext(Ctx);
+}
+
+export function RouterProvider({ children }: { children: ReactNode }) {
+  const [page, setPage] = useState<Page>("home");
+  const navigate = useCallback((p: Page) => setPage(p), []);
+  const value = useMemo(() => ({ page, navigate }), [page, navigate]);
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}

--- a/src/content/projects/nespresso-color-filter.mdx
+++ b/src/content/projects/nespresso-color-filter.mdx
@@ -37,6 +37,7 @@ We had a chance to test something fresh during a one-week design sprint. We pull
   <NespressoHero />
   <NespressoCoffeeCorner />
   <NespressoOatlyVideo />
+  <NespressoMoodBubbles />
   <NespressoRecycling />
   <NespressoBoutique />
   <NespressoFooter />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,4 @@
+@import url("https://fonts.googleapis.com/css2?family=Host+Grotesk:ital,wght@0,300..800;1,300..800&display=swap");
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 


### PR DESCRIPTION
- NespressoMoodBubbles: 11 floating draggable bubbles with custom physics (ambient drift, pairwise collisions, wall bounce). Multi-select drives the "Let's make some coffee" CTA enabled state
- NespressoCoffeePage + _router-context: tap "Shop Coffee" in the hero to swap the home content for a Coffee PLP (title, filters, 2-col product grid with quantity steppers, footer). Same scroll container, scroll resets on route change
- Host Grotesk swapped in as the prototype-only font family
- Eyebrow labels in cards: removed uppercase + tracking-wider, larger rounded-3xl, recipe card now "White Chocolate Strawberry"
- Recycling and Boutique titles unified at text-22 font-normal
- Boutique gradient flipped to a vertical fade for legibility