### PR TITLE
feat(nespresso): live prototype analytics + serif italic swap

### DIFF
--- a/src/app/api/proto-events/route.ts
+++ b/src/app/api/proto-events/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { ALLOWED_EVENTS, EVENTS_HASH } from "@/lib/proto/events";
+import { hincrby, isKvConfigured } from "@/lib/proto/kv";
+
+export const runtime = "edge";
+
+/**
+ * POST /api/proto-events
+ * Body: { event: string }
+ *
+ * Validates against the allowlist, then HINCRBYs the matching field in the
+ * shared events hash. Returns 204 on success — there's nothing for the
+ * client to do with the response, this is fire-and-forget telemetry.
+ */
+export async function POST(req: Request) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "bad json" }, { status: 400 });
+  }
+
+  const event =
+    body && typeof body === "object" && "event" in body
+      ? (body as { event: unknown }).event
+      : null;
+
+  if (typeof event !== "string" || !ALLOWED_EVENTS.has(event)) {
+    return NextResponse.json({ error: "unknown event" }, { status: 400 });
+  }
+
+  // No KV configured (local dev, preview deploys without integration): accept
+  // silently so the client doesn't think it's broken.
+  if (!isKvConfigured()) {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  try {
+    await hincrby(EVENTS_HASH, event, 1);
+  } catch (e) {
+    console.warn("[proto-events] hincrby failed", e);
+    // Still 204 — we don't want to leak infra errors back to the client.
+  }
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -8,6 +8,11 @@ import ScrollReveal from "@/components/ui/ScrollReveal";
 
 type Params = Promise<{ slug: string }>;
 
+// Revalidate every 5 minutes so the <PrototypeStats /> easter egg on the
+// Nespresso article (and any future live data) stays fresh-ish without
+// turning every project page into a per-request render.
+export const revalidate = 300;
+
 export async function generateStaticParams() {
   return getProjectSlugs().map((slug) => ({ slug }));
 }

--- a/src/components/mdx/ArticleViewTracker.tsx
+++ b/src/components/mdx/ArticleViewTracker.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect } from "react";
+import { trackEvent } from "@/lib/proto/events";
+
+/**
+ * Fires a single `article_viewed` ping on mount. Dropped near the top of the
+ * Nespresso MDX so the <PrototypeStats /> block at the bottom can express
+ * the other funnel metrics as a percentage of total article visits.
+ */
+export default function ArticleViewTracker() {
+  useEffect(() => {
+    trackEvent("article_viewed");
+  }, []);
+  return null;
+}

--- a/src/components/mdx/Hypothesis.tsx
+++ b/src/components/mdx/Hypothesis.tsx
@@ -25,7 +25,7 @@ export default function Hypothesis({
         {title}
       </h3>
       {claim ? (
-        <p className="font-display my-6 text-[19px] italic leading-snug text-white">
+        <p className="my-6 text-[19px] italic leading-snug text-white">
           &ldquo;{claim}&rdquo;
         </p>
       ) : null}

--- a/src/components/mdx/InterviewBubbles.tsx
+++ b/src/components/mdx/InterviewBubbles.tsx
@@ -28,12 +28,11 @@ export default function InterviewBubbles({
   answers,
 }: InterviewBubblesProps) {
   const parsed: Answer[] = JSON.parse(answers);
-  const serif = !question;
 
   return (
     <div className="not-prose mx-auto mt-12 mb-16 max-w-3xl">
       {question ? (
-        <p className="font-display italic text-center text-2xl md:text-4xl text-white/85 leading-none mb-6">
+        <p className="italic text-center text-2xl md:text-4xl text-white/85 leading-tight mb-6 tracking-tight">
           “{question}”
         </p>
       ) : null}
@@ -41,9 +40,7 @@ export default function InterviewBubbles({
         {parsed.map((a, i) => (
           <div
             key={i}
-            className={`rounded-full border border-white/15 px-6 py-3 text-center text-base md:text-lg text-white/85 ${
-              serif ? "font-display italic" : ""
-            }`}
+            className="rounded-full border border-white/15 px-6 py-3 text-center text-base md:text-lg text-white/85"
           >
             “{highlight(a.text, a.colorWord, a.color)}”
           </div>

--- a/src/components/mdx/PrototypeStats.tsx
+++ b/src/components/mdx/PrototypeStats.tsx
@@ -1,0 +1,162 @@
+import { getProtoStats } from "@/lib/proto/stats";
+import { COLOR_GROUPS } from "@/lib/proto/color-groups";
+
+/**
+ * Easter-egg block at the end of the Nespresso case study. Reads aggregated
+ * event counters from Redis (Vercel KV / Upstash) and renders a small
+ * editorial-style report — the meta point being that code prototypes can
+ * quietly collect quantitative data alongside qualitative findings.
+ *
+ * Server component so we can hit Redis directly. The host page sets a
+ * 5-minute revalidate so numbers stay fresh-ish without hammering KV.
+ */
+export default async function PrototypeStats() {
+  const stats = await getProtoStats();
+
+  const totalAddToCart = stats.perColor.reduce(
+    (sum, c) => sum + c.addToCart,
+    0,
+  );
+  const maxAddToCart = Math.max(...stats.perColor.map((c) => c.addToCart), 1);
+  const sorted = [...stats.perColor].sort((a, b) => b.addToCart - a.addToCart);
+  const swatchById = Object.fromEntries(
+    COLOR_GROUPS.map((g) => [g.id, { label: g.label, swatch: g.swatch }]),
+  );
+
+  const {
+    articleViewed,
+    coffeePlpViewed,
+    filterPanelOpened,
+    subscriptionExplored,
+    checkoutReached,
+  } = stats.totals;
+
+  // "Visited the coffee list page" is expressed off article views; the
+  // remaining three rates use the same article-view baseline so every
+  // percentage on the page reads against the same denominator.
+  const visitRate = pct(coffeePlpViewed, articleViewed);
+  const filterRate = pct(filterPanelOpened, articleViewed);
+  const subscriptionRate = pct(subscriptionExplored, articleViewed);
+  const checkoutRate = pct(checkoutReached, articleViewed);
+
+  return (
+    <section className="mx-auto my-16 max-w-3xl">
+      <div className="not-prose text-[11px] font-normal uppercase tracking-[0.18em] text-white/40">
+        P.S. — live data of the prototype
+      </div>
+      {/* Inherit prose-lg sizing/weight from the article, but pull the
+          top margin in so the eyebrow above hugs the heading. */}
+      <h2 className="!mt-2">When qualitative prototypes turn quantitative.</h2>
+      <p>
+        As prototype above is real code, it can also track events. This is a
+        live demonstration of how people that visited this portfolio have
+        interacted with it.
+      </p>
+
+      {/* Baseline: total article readers. The four rates below are all
+          measured off this number so they're directly comparable. */}
+      <div className="not-prose mt-7 text-center">
+        <div className="font-display text-[44px] leading-none tracking-tight text-white">
+          {fmt(articleViewed)}
+        </div>
+        <div className="mt-2 text-[12px] uppercase tracking-[0.18em] text-white/40">
+          readers of this article
+        </div>
+      </div>
+
+      {/* Four conversion rates, all measured off article views. */}
+      <div className="not-prose mt-6 grid grid-cols-2 gap-3 text-center sm:grid-cols-4">
+        <RateCell
+          value={visitRate}
+          label="visited the coffee list page"
+          empty={!articleViewed}
+        />
+        <RateCell
+          value={filterRate}
+          label="opened the filters"
+          empty={!articleViewed}
+        />
+        <RateCell
+          value={subscriptionRate}
+          label="checked the subscription"
+          empty={!articleViewed}
+        />
+        <RateCell
+          value={checkoutRate}
+          label="finished the purchase"
+          empty={!articleViewed}
+        />
+      </div>
+
+      {/* Per-color add-to-cart leaderboard */}
+      <div className="not-prose mt-8">
+        <div className="text-[11px] font-normal uppercase tracking-[0.18em] text-white/40">
+          Add to cart, by color · {fmt(totalAddToCart)} total
+        </div>
+        <ul className="mt-3 space-y-2">
+          {sorted.map((row) => {
+            const meta = swatchById[row.color];
+            if (!meta) return null;
+            const widthPct = Math.round((row.addToCart / maxAddToCart) * 100);
+            return (
+              <li
+                key={row.color}
+                className="grid grid-cols-[80px_1fr_44px] items-center gap-3 text-[14px]"
+              >
+                <div className="flex items-center gap-2 text-white/80">
+                  <span
+                    aria-hidden
+                    className="inline-block h-3 w-3 rounded-full border border-white/20"
+                    style={{ backgroundColor: meta.swatch }}
+                  />
+                  <span>{meta.label}</span>
+                </div>
+                <div className="h-2 overflow-hidden rounded-full bg-white/[0.06]">
+                  <div
+                    className="h-full rounded-full transition-[width] duration-500"
+                    style={{
+                      width: `${widthPct}%`,
+                      backgroundColor: meta.swatch,
+                    }}
+                  />
+                </div>
+                <div className="text-right tabular-nums text-white/70">
+                  {fmt(row.addToCart)}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </section>
+  );
+}
+
+function RateCell({
+  value,
+  label,
+  empty,
+}: {
+  value: string;
+  label: string;
+  empty: boolean;
+}) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+      <div className="font-display text-[32px] leading-none tracking-tight text-white">
+        {empty ? "—" : value}
+      </div>
+      <div className="mt-2 text-[12px] leading-snug text-white/60">{label}</div>
+    </div>
+  );
+}
+
+function fmt(n: number) {
+  return n.toLocaleString("en-US");
+}
+
+function pct(numerator: number, denominator: number) {
+  if (!denominator) return "0%";
+  const value = Math.round((numerator / denominator) * 100);
+  return `${value}%`;
+}

--- a/src/components/mdx/index.tsx
+++ b/src/components/mdx/index.tsx
@@ -6,6 +6,8 @@ import { KeyPoints, KeyPoint } from "./KeyPoints";
 import Hypothesis from "./Hypothesis";
 import { Metrics, Metric } from "./Metrics";
 import PhoneEmbed from "../projects/nespresso/PhoneEmbed";
+import PrototypeStats from "./PrototypeStats";
+import ArticleViewTracker from "./ArticleViewTracker";
 
 export const mdxComponents: MDXComponents = {
   ProjectImage,
@@ -17,4 +19,6 @@ export const mdxComponents: MDXComponents = {
   Metrics,
   Metric,
   PhoneEmbed,
+  PrototypeStats,
+  ArticleViewTracker,
 };

--- a/src/components/projects/nespresso/NespressoCart.tsx
+++ b/src/components/projects/nespresso/NespressoCart.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useCart } from "./_cart-context";
 import capsulesData from "./capsules.json";
+import { trackEvent } from "@/lib/proto/events";
 
 type Capsule = {
   id: number;
@@ -134,8 +135,20 @@ export default function NespressoCart() {
   const [subscribe, setSubscribe] = useState(false);
   const [frequency, setFrequency] = useState(FREQUENCIES[0]);
 
+  // Fire once per closed → open transition so a single drawer open counts
+  // once, not on every re-render while open.
+  useEffect(() => {
+    if (open) trackEvent("cart_opened");
+  }, [open]);
+
   const handleCheckout = () => {
+    trackEvent("checkout_reached");
     setCheckedOut(true);
+  };
+
+  const handleSubscribeClick = () => {
+    trackEvent("subscription_explored");
+    setSubscribe(true);
   };
 
   const handleClose = () => {
@@ -442,7 +455,7 @@ export default function NespressoCart() {
             </button>
             <button
               type="button"
-              onClick={() => setSubscribe(true)}
+              onClick={handleSubscribeClick}
               aria-pressed={subscribe}
               className={`relative flex h-full flex-1 items-center justify-center gap-1.5 rounded-full transition-colors duration-200 ${
                 subscribe ? "text-black" : "text-stone-500"

--- a/src/components/projects/nespresso/NespressoCoffeePage.tsx
+++ b/src/components/projects/nespresso/NespressoCoffeePage.tsx
@@ -7,6 +7,12 @@ import NespressoNavBar from "./NespressoNavBar";
 import NespressoFooter from "./NespressoFooter";
 import capsulesData from "./capsules.json";
 import { useCart } from "./_cart-context";
+import {
+  COLOR_GROUPS,
+  colorForCapsule,
+  type ColorGroupId,
+} from "@/lib/proto/color-groups";
+import { trackEvent } from "@/lib/proto/events";
 
 type Capsule = {
   id: number;
@@ -38,26 +44,9 @@ const SIZE_FILTERS: Array<{ id: string; label: string; icon: string }> = [
   { id: "carafe",          label: "Carafe",          icon: "/images/projects/nespresso/icons/cupsize-carafe.svg" },
 ];
 
-// Plain-colour buckets. Each capsule belongs to one bucket based on its
-// dominant hue. The `swatch` is the hex shown next to each chip.
-const COLOR_GROUPS: Array<{
-  id: string;
-  label: string;
-  swatch: string;
-  ids: number[];
-}> = [
-  { id: "yellow", label: "Yellow", swatch: "#F0B430", ids: [1, 2, 3, 4, 7] },
-  { id: "orange", label: "Orange", swatch: "#C0843C", ids: [5, 6] },
-  { id: "pink",   label: "Pink",   swatch: "#E4786C", ids: [10] },
-  { id: "red",    label: "Red",    swatch: "#CC4848", ids: [8, 9, 11] },
-  { id: "purple", label: "Purple", swatch: "#542478", ids: [12, 13, 14] },
-  { id: "navy",   label: "Navy",   swatch: "#0C183C", ids: [15, 17, 18] },
-  { id: "blue",   label: "Blue",   swatch: "#0090C0", ids: [19, 20] },
-  { id: "green",  label: "Green",  swatch: "#547818", ids: [22, 23, 24, 25, 26] },
-  { id: "brown",  label: "Brown",  swatch: "#543018", ids: [27, 28, 29, 30] },
-  { id: "grey",   label: "Grey",   swatch: "#909090", ids: [21, 31] },
-  { id: "black",  label: "Black",  swatch: "#181818", ids: [16, 32] },
-];
+// Plain-colour buckets are defined in `@/lib/proto/color-groups` (shared
+// with the analytics layer so add-to-cart and filter events can be bucketed
+// without duplicating the mapping).
 
 // Distribute intensities across the 1–13 scale so cards don't all show the
 // same number. Replace with real data when available.
@@ -206,7 +195,11 @@ function ProductCard({
         <button
           type="button"
           aria-label={inCart ? "Increase" : `Add ${capsule.name}`}
-          onClick={() => add(capsule.id)}
+          onClick={() => {
+            const color = colorForCapsule(capsule.id);
+            if (color) trackEvent(`add_to_cart:${color}`);
+            add(capsule.id);
+          }}
           className="absolute inset-y-0 right-0 my-auto flex h-8 w-8 items-center justify-center rounded-full bg-black/10 text-black transition-transform duration-150 ease-out active:scale-95"
         >
           <PlusIcon />
@@ -260,6 +253,11 @@ export default function NespressoCoffeePage() {
   const [activeColors, setActiveColors] = useState<string[]>([]);
   const [activeSizes, setActiveSizes] = useState<string[]>([]);
 
+  // Page-view ping. Runs once on mount.
+  useEffect(() => {
+    trackEvent("coffee_plp_viewed");
+  }, []);
+
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
     const allowedColorIds = activeColors.length
@@ -291,9 +289,15 @@ export default function NespressoCoffeePage() {
       prev.includes(i) ? prev.filter((x) => x !== i) : [...prev, i]
     );
   const toggleColor = (id: string) =>
-    setActiveColors((prev) =>
-      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
-    );
+    setActiveColors((prev) => {
+      const turningOn = !prev.includes(id);
+      // Only count the activation side — turning a filter off shouldn't
+      // double-count as engagement with that color.
+      if (turningOn) {
+        trackEvent(`color_filter_applied:${id as ColorGroupId}`);
+      }
+      return turningOn ? [...prev, id] : prev.filter((x) => x !== id);
+    });
   const toggleSize = (id: string) =>
     setActiveSizes((prev) =>
       prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
@@ -362,7 +366,14 @@ export default function NespressoCoffeePage() {
           />
           <button
             type="button"
-            onClick={() => setFilterOpen((o) => !o)}
+            onClick={() => {
+              setFilterOpen((o) => {
+                // Only count the opening action, not closing — matches the
+                // "users that opened the filters" reading in the funnel.
+                if (!o) trackEvent("filter_panel_opened");
+                return !o;
+              });
+            }}
             aria-label={`Filters${filterCount > 0 ? ` (${filterCount} active)` : ""}`}
             aria-expanded={filterOpen}
             className={`flex h-9 shrink-0 items-center rounded-full px-3 transition-[background,color] duration-200 ${

--- a/src/components/projects/nespresso/PhoneEmbed.tsx
+++ b/src/components/projects/nespresso/PhoneEmbed.tsx
@@ -72,7 +72,7 @@ export default function PhoneEmbed({
         </div>
       </div>
 
-      <p className="font-display max-w-lg text-center text-[16px] my-2 italic leading-snug text-white/70">
+      <p className="max-w-lg text-center text-[16px] my-2 italic leading-snug text-white/70">
         Prototyping is changing fast, with AI we can now build projects like
         this one in a few hours. Results are much more accurate & measurable
         than they used to be with Figma.

--- a/src/content/projects/nespresso-color-filter.mdx
+++ b/src/content/projects/nespresso-color-filter.mdx
@@ -8,6 +8,8 @@ color: "#5C3D8C"
 featured: true
 ---
 
+<ArticleViewTracker />
+
 A pattern emerged interview after interview:
 
 <InterviewBubbles
@@ -111,3 +113,5 @@ Design sprints are a great way to step out of the regular cadence, test ideas th
 Separate teams are currently testing the color filter and **a semantic search** where typing _"blue"_ surfaces the blue capsules, _"strong"_ surfaces the high-intensity ones, and so on. A different shape, same mental model underneath.
 
 The subscription upsell at the end of the purchase flow is in the pipeline to be tested next. Big-company timelines being what they are, the prototype raised enough eyebrows in the right rooms that the idea is being seriously considered. That's already a useful outcome for a week-long sprint.
+
+<PrototypeStats />

--- a/src/lib/proto/color-groups.ts
+++ b/src/lib/proto/color-groups.ts
@@ -1,0 +1,60 @@
+/**
+ * Color buckets used by the Nespresso prototype color filter and by the
+ * analytics layer that aggregates "add to cart" events per color.
+ *
+ * `ids` lists the capsule ids that belong to each bucket. This is the single
+ * source of truth — both the filter UI and `colorForCapsule()` import it.
+ */
+export const COLOR_GROUPS: Array<{
+  id: ColorGroupId;
+  label: string;
+  swatch: string;
+  ids: number[];
+}> = [
+  { id: "yellow", label: "Yellow", swatch: "#F0B430", ids: [1, 2, 3, 4, 7] },
+  { id: "orange", label: "Orange", swatch: "#C0843C", ids: [5, 6] },
+  { id: "pink", label: "Pink", swatch: "#E4786C", ids: [10] },
+  { id: "red", label: "Red", swatch: "#CC4848", ids: [8, 9, 11] },
+  { id: "purple", label: "Purple", swatch: "#542478", ids: [12, 13, 14] },
+  { id: "navy", label: "Navy", swatch: "#0C183C", ids: [15, 17, 18] },
+  { id: "blue", label: "Blue", swatch: "#0090C0", ids: [19, 20] },
+  { id: "green", label: "Green", swatch: "#547818", ids: [22, 23, 24, 25, 26] },
+  { id: "brown", label: "Brown", swatch: "#543018", ids: [27, 28, 29, 30] },
+  { id: "grey", label: "Grey", swatch: "#909090", ids: [21, 31] },
+  { id: "black", label: "Black", swatch: "#181818", ids: [16, 32] },
+];
+
+export type ColorGroupId =
+  | "yellow"
+  | "orange"
+  | "pink"
+  | "red"
+  | "purple"
+  | "navy"
+  | "blue"
+  | "green"
+  | "brown"
+  | "grey"
+  | "black";
+
+export const COLOR_GROUP_IDS: ColorGroupId[] = [
+  "yellow",
+  "orange",
+  "pink",
+  "red",
+  "purple",
+  "navy",
+  "blue",
+  "green",
+  "brown",
+  "grey",
+  "black",
+];
+
+/** Reverse lookup: capsule id → color bucket id, or null if unmapped. */
+export function colorForCapsule(capsuleId: number): ColorGroupId | null {
+  for (const g of COLOR_GROUPS) {
+    if (g.ids.includes(capsuleId)) return g.id;
+  }
+  return null;
+}

--- a/src/lib/proto/events.ts
+++ b/src/lib/proto/events.ts
@@ -1,0 +1,52 @@
+import { COLOR_GROUP_IDS, type ColorGroupId } from "./color-groups";
+
+/**
+ * Allowlist of event names that the API will accept. Anything else gets a
+ * 400 — this prevents random callers from polluting the Redis hash with
+ * arbitrary fields.
+ */
+export type ProtoEvent =
+  | "article_viewed"
+  | "coffee_plp_viewed"
+  | "filter_panel_opened"
+  | "cart_opened"
+  | "subscription_explored"
+  | "checkout_reached"
+  | `color_filter_applied:${ColorGroupId}`
+  | `add_to_cart:${ColorGroupId}`;
+
+export const ALLOWED_EVENTS: ReadonlySet<string> = new Set<string>([
+  "article_viewed",
+  "coffee_plp_viewed",
+  "filter_panel_opened",
+  "cart_opened",
+  "subscription_explored",
+  "checkout_reached",
+  ...COLOR_GROUP_IDS.map((c) => `color_filter_applied:${c}`),
+  ...COLOR_GROUP_IDS.map((c) => `add_to_cart:${c}`),
+]);
+
+/** Redis hash key holding every counter. */
+export const EVENTS_HASH = "nespresso:events";
+
+/**
+ * Fire-and-forget. Best-effort POST to the analytics endpoint, never throws,
+ * never blocks the UI. Safe to call from anywhere on the client.
+ */
+export function trackEvent(event: ProtoEvent): void {
+  if (typeof window === "undefined") return;
+  try {
+    // keepalive lets the request finish even if the user is navigating away
+    // (e.g. after tapping "checkout" in the iframe).
+    fetch("/api/proto-events", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ event }),
+      keepalive: true,
+    }).catch(() => {
+      /* swallow */
+    });
+  } catch {
+    /* swallow */
+  }
+}

--- a/src/lib/proto/kv.ts
+++ b/src/lib/proto/kv.ts
@@ -1,0 +1,73 @@
+/**
+ * Minimal Upstash Redis REST wrapper. We hit the REST API directly instead
+ * of pulling in `@vercel/kv` / `@upstash/redis` — we only need HINCRBY and
+ * HGETALL, and avoiding the dep keeps the bundle small.
+ *
+ * Env vars (Vercel injects these when you connect a KV/Upstash integration):
+ *   - KV_REST_API_URL
+ *   - KV_REST_API_TOKEN
+ *
+ * If they're missing (local dev without KV), every call no-ops gracefully
+ * and `hgetall` returns an empty object — the stats component then shows a
+ * placeholder instead of throwing.
+ */
+
+function kvConfig() {
+  const url = process.env.KV_REST_API_URL;
+  const token = process.env.KV_REST_API_TOKEN;
+  if (!url || !token) return null;
+  return { url, token };
+}
+
+export function isKvConfigured() {
+  return kvConfig() !== null;
+}
+
+async function call<T>(path: string[]): Promise<T | null> {
+  const cfg = kvConfig();
+  if (!cfg) return null;
+  const res = await fetch(
+    `${cfg.url}/${path.map(encodeURIComponent).join("/")}`,
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${cfg.token}` },
+      cache: "no-store",
+    },
+  );
+  if (!res.ok) {
+    console.warn("[kv] request failed", res.status, path[0]);
+    return null;
+  }
+  const json = (await res.json()) as { result: T };
+  return json.result;
+}
+
+/** Atomically increment a hash field by 1. Returns the new value, or null. */
+export function hincrby(key: string, field: string, by = 1) {
+  return call<number>(["hincrby", key, field, String(by)]);
+}
+
+/** Read the full hash. Returns {} when KV is not configured. */
+export async function hgetall(key: string): Promise<Record<string, string>> {
+  const result = await call<unknown>(["hgetall", key]);
+  if (!result) return {};
+  // Upstash REST returns either an object or a flat [k, v, k, v] array
+  // depending on version. Normalize both shapes.
+  if (Array.isArray(result)) {
+    const out: Record<string, string> = {};
+    for (let i = 0; i < result.length; i += 2) {
+      const k = result[i];
+      const v = result[i + 1];
+      if (typeof k === "string") out[k] = String(v ?? "");
+    }
+    return out;
+  }
+  if (result && typeof result === "object") {
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(result as Record<string, unknown>)) {
+      out[k] = String(v ?? "");
+    }
+    return out;
+  }
+  return {};
+}

--- a/src/lib/proto/stats.ts
+++ b/src/lib/proto/stats.ts
@@ -1,0 +1,50 @@
+import { hgetall, isKvConfigured } from "./kv";
+import {
+  COLOR_GROUP_IDS,
+  type ColorGroupId,
+} from "./color-groups";
+import { EVENTS_HASH } from "./events";
+
+export type ProtoStats = {
+  configured: boolean;
+  totals: {
+    articleViewed: number;
+    coffeePlpViewed: number;
+    filterPanelOpened: number;
+    cartOpened: number;
+    subscriptionExplored: number;
+    checkoutReached: number;
+  };
+  perColor: Array<{
+    color: ColorGroupId;
+    filterApplied: number;
+    addToCart: number;
+  }>;
+};
+
+/**
+ * Server-side read of the prototype event counters. Wraps the Redis HGETALL
+ * call in a typed shape the MDX component can consume directly.
+ */
+export async function getProtoStats(): Promise<ProtoStats> {
+  const configured = isKvConfigured();
+  const raw = configured ? await hgetall(EVENTS_HASH) : {};
+  const get = (k: string) => Number.parseInt(raw[k] ?? "0", 10) || 0;
+
+  return {
+    configured,
+    totals: {
+      articleViewed: get("article_viewed"),
+      coffeePlpViewed: get("coffee_plp_viewed"),
+      filterPanelOpened: get("filter_panel_opened"),
+      cartOpened: get("cart_opened"),
+      subscriptionExplored: get("subscription_explored"),
+      checkoutReached: get("checkout_reached"),
+    },
+    perColor: COLOR_GROUP_IDS.map((color) => ({
+      color,
+      filterApplied: get(`color_filter_applied:${color}`),
+      addToCart: get(`add_to_cart:${color}`),
+    })),
+  };
+}


### PR DESCRIPTION
- Track article views, PLP visits, filter opens, cart opens, subscription explores, checkout reaches, and per-color add-to-cart events from the Nespresso prototype. Counters live in a single Redis hash via Upstash REST (no new npm dep); the API route degrades to a 204 no-op when KV env vars aren't set.
- Add <PrototypeStats /> easter-egg block at the end of the case study rendering a readers baseline + four conversion rates and a per-color add-to-cart leaderboard. Project page revalidates every 5 min.
- Swap Playfair italic for Geist (sans) in Hypothesis claim, Interview bubbles, and PhoneEmbed caption — italic stayed, just no longer serif.