### PR TITLE
fix(nespresso): dedupe proto events per browser via localStorage

### DIFF
--- a/src/lib/proto/events.ts
+++ b/src/lib/proto/events.ts
@@ -30,11 +30,36 @@ export const ALLOWED_EVENTS: ReadonlySet<string> = new Set<string>([
 export const EVENTS_HASH = "nespresso:events";
 
 /**
- * Fire-and-forget. Best-effort POST to the analytics endpoint, never throws,
- * never blocks the UI. Safe to call from anywhere on the client.
+ * localStorage prefix for the once-per-browser dedupe flags. Each event
+ * (including parameterized ones like `add_to_cart:purple`) gets its own
+ * key, so we count unique readers per event rather than raw taps. That
+ * keeps every percentage in the easter-egg block bounded by article views
+ * and prevents the funnel from going past 100% if a reader, say, opens
+ * the cart twice or restarts the flow after finishing the purchase.
+ *
+ * Shared across the parent article and the iframe because they're on the
+ * same origin.
+ */
+const DEDUPE_PREFIX = "nespresso-evt:";
+
+/**
+ * Fire-and-forget. Best-effort POST to the analytics endpoint, deduped per
+ * browser via localStorage. Never throws, never blocks the UI.
  */
 export function trackEvent(event: ProtoEvent): void {
   if (typeof window === "undefined") return;
+
+  // Dedupe: if this browser already fired this event, drop the call so
+  // each counter stays a count of unique readers.
+  try {
+    const key = DEDUPE_PREFIX + event;
+    if (window.localStorage.getItem(key)) return;
+    window.localStorage.setItem(key, "1");
+  } catch {
+    /* localStorage disabled / full — still fire the event so users
+       with privacy-locked browsers aren't completely silent. */
+  }
+
   try {
     // keepalive lets the request finish even if the user is navigating away
     // (e.g. after tapping "checkout" in the iframe).


### PR DESCRIPTION
Each event now fires at most once per browser, so every counter measures unique readers rather than raw taps. Prevents funnel percentages from exceeding 100% when a reader opens the cart twice, restarts the flow after finishing checkout, or otherwise re-triggers actions during the same session.