### PR TITLE
fix(nespresso): keep proto stats color rows in rainbow order

### DIFF
--- a/src/components/mdx/PrototypeStats.tsx
+++ b/src/components/mdx/PrototypeStats.tsx
@@ -18,7 +18,9 @@ export default async function PrototypeStats() {
     0,
   );
   const maxAddToCart = Math.max(...stats.perColor.map((c) => c.addToCart), 1);
-  const sorted = [...stats.perColor].sort((a, b) => b.addToCart - a.addToCart);
+  // Keep the COLOR_GROUPS rainbow order — yellow → orange → … → black —
+  // so the column reads as a consistent spectrum no matter which color
+  // is leading.
   const swatchById = Object.fromEntries(
     COLOR_GROUPS.map((g) => [g.id, { label: g.label, swatch: g.swatch }]),
   );
@@ -94,7 +96,7 @@ export default async function PrototypeStats() {
           Add to cart, by color · {fmt(totalAddToCart)} total
         </div>
         <ul className="mt-3 space-y-2">
-          {sorted.map((row) => {
+          {stats.perColor.map((row) => {
             const meta = swatchById[row.color];
             if (!meta) return null;
             const widthPct = Math.round((row.addToCart / maxAddToCart) * 100);


### PR DESCRIPTION
Stop sorting the per-color add-to-cart leaderboard by count — the row order now matches the COLOR_GROUPS spectrum so the column always reads as a stable rainbow. Bar widths still scale to the leading color, so the winner is still visually obvious.